### PR TITLE
SourceClear fixes for vulnerable libraries.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,11 +2,11 @@
   "name": "example-javascript-bower",
   "version": "0.0.1",
   "dependencies": {
-    "dojo": "1.3.0",
-    "validator-js": "~1.0.0",
-    "mapbox.js": "~1.6.4",
-    "jquery": "1.7.1",
-    "ember": "1.2.0",
+    "dojo": "1.4.2rc1",
+    "validator-js": "3.22.1",
+    "mapbox.js": "2.0.0-beta0",
+    "jquery": "3.0.0-beta1",
+    "ember": "1.4.0-beta.2",
     "angular": "1.0.8"
   }
 }


### PR DESCRIPTION
SourceClear generated this pull request to update the following vulnerable libraries.

| Type | Library | From | To |
| --- | --- | --- | --- |
| BOWER | `validator-js` | 1.0.0 | 3.22.1 |
| BOWER | `mapbox.js` | 1.6.4 | 2.0.0-beta0 |
| BOWER | `ember` | 1.2.0 | 1.4.0-beta.2 |
| BOWER | `jquery` | 1.7.1 | 3.0.0-beta1 |
| BOWER | `dojo` | 1.3.0 | 1.4.2rc1 |

<!-- srcclr-pr-id-7fbb761875fc28389bea953310d8efe788d82e84b862bff6d96f605672d66f86 -->
